### PR TITLE
force df.to_csv sting to decode to ascii

### DIFF
--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -71,6 +71,6 @@ from IPython.display import IFrame
 
 def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500"):
     with open(outfile_path, 'w') as outfile:
-        outfile.write(template % df.to_csv())
+        outfile.write(template % df.to_csv().decode("ascii", "ignore"))
     return IFrame(src=outfile_path, width=width, height=height)
         


### PR DESCRIPTION
The string that is generated by to_csv() from unicode dataframes was
giving me some troubles! Forced it to decode to ascii with ignore for
the missing chars. I guess there is a more elegant way to go about this!
