### PR TITLE
Allow "pivot_ui" to receive some config. params for the Javascript widget

### DIFF
--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -1,14 +1,19 @@
+# coding: utf8
+
 # %install_ext http://nicolas.kruchten.com/pivottable/jupyter/pivottablejs.py
 # %load_ext pivottablejs
 # %pivottablejs data_frame
 
 
-template = u"""
+template = """
 <!DOCTYPE html>
 <html>
     <head>
-        <title>PivotTable.js</title>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         
+        <title>PivotTable.js</title>
+
         <!-- external libs from cdnjs -->
         <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.css">
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
@@ -83,9 +88,10 @@ def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500",
         outfile.write(template % { "df":df.to_csv() , "pivot_extras":json.dumps(pivot_extras) } )
         
     return IFrame(src=outfile_path, width=width, height=height)
+        
 
 # EXAMPLE:
 # import pandas as pd
+# from pivottablejs import pivot_ui
 # df = pd.DataFrame({"a":["col","alto","ancho","bla"],"b":[2,3,4,5],"c":[6,2,6,8]});
-# %run ~/work/yumok_modules/pivottablejs/__init__.py
 # pivot_ui(df,rows=["a"],cols=["b"],vals=["c"],aggregatorName="Sum",rendererName = "Heatmap")

--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -76,11 +76,11 @@ import json
 def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500", **kargs):
     pivot_extras = {}
     for key in ["rows","cols","aggregatorName","vals","rendererName"]:
-        if kargs[key]:
+        if key in kargs.keys():
             pivot_extras[key] = kargs[key]
         
     with open(outfile_path, 'w') as outfile:
-        outfile.write(template % { df:df.to_csv() , pivot_extras:json.dumps(pivot_extras) } )
+        outfile.write(template % { "df":df.to_csv() , "pivot_extras":json.dumps(pivot_extras) } )
         
     return IFrame(src=outfile_path, width=width, height=height)
         

--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -3,7 +3,7 @@
 # %pivottablejs data_frame
 
 
-template = """
+template = u"""
 <!DOCTYPE html>
 <html>
     <head>
@@ -50,27 +50,37 @@ template = """
                     
                 $("#output").pivotUI( 
                     $.csv.toArrays($("#output").text()), 
-                    { 
-                        renderers: $.extend(
-                            $.pivotUtilities.renderers, 
-                            $.pivotUtilities.c3_renderers, 
-                            $.pivotUtilities.d3_renderers,
-                            $.pivotUtilities.export_renderers
-                            ),
-                        hiddenAttributes: [""]
-                    }
+                    $.extend({ 
+                            renderers: $.extend(
+                                $.pivotUtilities.renderers, 
+                                $.pivotUtilities.c3_renderers, 
+                                $.pivotUtilities.d3_renderers,
+                                $.pivotUtilities.export_renderers
+                                ),
+                            hiddenAttributes: [""]
+                        }
+                        ,
+                        %(pivot_extras)s
+                    )
                 ).show();
              });
         </script>
-        <div id="output" style="display: none;">%s</div>
+        <div id="output" style="display: none;">%(df)s</div>
     </body>
 </html>
 """
 
 from IPython.display import IFrame
+import json
 
-def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500"):
+def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500", **kargs):
+    pivot_extras = {}
+    for key in ["rows","cols","aggregatorName","vals","rendererName"]:
+        if kargs[key]:
+            pivot_extras[key] = kargs[key]
+        
     with open(outfile_path, 'w') as outfile:
-        outfile.write(template % df.to_csv())
+        outfile.write(template % { df:df.to_csv() , pivot_extras:json.dumps(pivot_extras) } )
+        
     return IFrame(src=outfile_path, width=width, height=height)
         

--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -83,4 +83,9 @@ def pivot_ui(df, outfile_path = "pivottablejs.html", width="100%", height="500",
         outfile.write(template % { "df":df.to_csv() , "pivot_extras":json.dumps(pivot_extras) } )
         
     return IFrame(src=outfile_path, width=width, height=height)
-        
+
+# EXAMPLE:
+# import pandas as pd
+# df = pd.DataFrame({"a":["col","alto","ancho","bla"],"b":[2,3,4,5],"c":[6,2,6,8]});
+# %run ~/work/yumok_modules/pivottablejs/__init__.py
+# pivot_ui(df,rows=["a"],cols=["b"],vals=["c"],aggregatorName="Sum",rendererName = "Heatmap")


### PR DESCRIPTION
Allow "pivot_ui" to receive some config. params for the Javascript widget, for example:

df = pd.DataFrame({"a":["col","alto","ancho","bla"],"b":[2,3,4,5],"c":[6,2,6,8]});
pivot_ui(df, rows=["a"],cols=["b"],vals=["c"],aggregatorName="Sum",rendererName = "Heatmap")