### PR TITLE
fix #52

### DIFF
--- a/pivottablejs/__init__.py
+++ b/pivottablejs/__init__.py
@@ -70,7 +70,7 @@ import json, io
 
 def pivot_ui(df, outfile_path = "pivottablejs.html", url="",
     width="100%", height="500", **kwargs):
-    with io.open(outfile_path, 'wt', encoding='utf8') as outfile:
+    with io.open(outfile_path, 'wt', newline="\n", encoding='utf8') as outfile:
         csv = df.to_csv(encoding='utf8')
         if hasattr(csv, 'decode'):
             csv = csv.decode('utf8')


### PR DESCRIPTION
specify a newline="\n" to ensure that on windows the csv has not "\r\n" as otherwise pivottable will see rows with null values